### PR TITLE
Giving footer some space, closes #11

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
     {% for contributor in site.data.contributorResponse.contributors%}
       {% assign loopindex = forloop.index | modulo: 2 %}
       {% if loopindex == 1 %}
-        <div class="flex flex-column items-center mv3 w-100 w-50-m w-auto-l">
+        <div class="flex flex-column items-center mv3 w-100 w-50-m w-20-l">
           <div>
             <a class="link" href={{ contributor.profile }}>
               <img src={{ contributor.avatar_url }} class="grow-large pa1 ba b--black-10 br-100 h3 w3" alt={{ contributor.name }}>


### PR DESCRIPTION
Just expanded how wide each contributor section is on large screens:

![image](https://user-images.githubusercontent.com/12476932/30778631-84b96aa2-a0a8-11e7-9d26-38d779d28ced.png)

I think that looks decent. Let me know what you think mate (and open to all suggestions)